### PR TITLE
Do not assume the client certificate is always present

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,13 @@ async function plugin (app, options) {
     const certificate = this.raw.socket.getPeerCertificate(false)
     const commonName = certificate?.subject?.CN
 
-    if (commonName && mtlsDomain && !commonName.endsWith(mtlsDomain)) {
-      app.log.error({ commonName }, 'Invalid certificate common name')
-      throw new Error('Invalid certificate common name')
-    }
-
     if (!commonName) {
       return {}
+    }
+
+    if (mtlsDomain && !commonName.endsWith(mtlsDomain)) {
+      app.log.error({ commonName }, 'Invalid certificate common name')
+      throw new Error('Invalid certificate common name')
     }
 
     const domains = commonName.slice(0, -mtlsDomain.length).split('.').reverse()

--- a/index.js
+++ b/index.js
@@ -12,11 +12,15 @@ async function plugin (app, options) {
     }
 
     const certificate = this.raw.socket.getPeerCertificate(false)
-    const commonName = certificate.subject.CN
+    const commonName = certificate?.subject?.CN
 
-    if (mtlsDomain && !commonName.endsWith(mtlsDomain)) {
+    if (commonName && mtlsDomain && !commonName.endsWith(mtlsDomain)) {
       app.log.error({ commonName }, 'Invalid certificate common name')
       throw new Error('Invalid certificate common name')
+    }
+
+    if (!commonName) {
+      return {}
     }
 
     const domains = commonName.slice(0, -mtlsDomain.length).split('.').reverse()


### PR DESCRIPTION
We need this because we want to support cases when we have `mTLS` configured but the client does not present a certificate. 
Currently it fails with: 
```
Cannot read properties of undefined (reading 'CN')","stack":"TypeError: Cannot read properties of undefined (reading 'CN')\n at _Request.getMtlsAuth (/opt/build/node_modules/.pnpm/@platformatic+mtls-auth@1.2.0/node_modules/@platformatic/mtls-auth/index.js:15:44)
````